### PR TITLE
libvirt: 6.0.0 -> 6.1.0, fix module

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -214,14 +214,14 @@ in {
     };
 
     systemd.services.libvirtd = {
-      description = "Libvirt Virtual Machine Management Daemon";
-
-      wantedBy = [ "multi-user.target" ];
       requires = [ "libvirtd-config.service" ];
       after = [ "systemd-udev-settle.service" "libvirtd-config.service" ]
               ++ optional vswitch.enable "ovs-vswitchd.service";
 
-      environment.LIBVIRTD_ARGS = ''--config "${configFile}" ${concatStringsSep " " cfg.extraOptions}'';
+      environment.LIBVIRTD_ARGS = concatMapStringsSep " " escapeShellArg (
+        [ "--config" configFile
+          "--timeout" "120"     # from ${libvirt}/var/lib/sysconfig/libvirtd
+        ] ++ cfg.extraOptions);
 
       path = [ cfg.qemuPackage ] # libvirtd requires qemu-img to manage disk images
              ++ optional vswitch.enable vswitch.package;
@@ -266,5 +266,8 @@ in {
       serviceConfig.ExecStart = "@${pkgs.libvirt}/sbin/virtlockd virtlockd";
       restartIfChanged = false;
     };
+
+    systemd.sockets.libvirtd    .wantedBy = [ "sockets.target" ];
+    systemd.sockets.libvirtd-tcp.wantedBy = [ "sockets.target" ];
   };
 }

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "6.0.0";
+  version = "6.1.0";
 
   src = assert version == libvirt.version; fetchgit {
     url = git://libvirt.org/libvirt-python.git;
     rev = "v${version}";
-    sha256 = "0p6a8mlqf1kb0pg1avygg6ymlfvqsk7qisyhmyaxkj4pn8q87cxy";
+    sha256 = "0h3w1p5y4kg2hdbhxmg4lphcnmr7979iwi0m750f8vzbfccsrp7k";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17169,11 +17169,11 @@ let
 
   SysVirt = buildPerlModule rec {
     pname = "Sys-Virt";
-    version = "6.0.0";
+    version = "6.1.0";
     src = assert version == pkgs.libvirt.version; pkgs.fetchgit {
       url = git://libvirt.org/libvirt-perl.git;
-      rev = "v${version}";
-      sha256 = "06r333bc52x0g511lw3nwp5w5q9d7mwxrbx5ihiv7shwyxn7dh93";
+      rev = "299f3ba34ae4daea966bf1cb07d90f4151da895f"; # there is no "v6.1.0" tag
+      sha256 = "0k18spb6r8fym5v4rsnma1fspnzqf1mgr2wkvb8s4cwn915sccp4";
     };
     nativeBuildInputs = [ pkgs.pkgconfig ];
     buildInputs = [ pkgs.libvirt CPANChanges TestPod TestPodCoverage XMLXPath ];


### PR DESCRIPTION
`libvirtd` rejects to start with `--listen` flag in presence of systemd, so I switched to socket activation.
it works on my laptop, but I have not tested yet various cases like restoring bridges after nixos-rebuild

cc @Izorkin